### PR TITLE
Add type casting integer to string

### DIFF
--- a/lib/web3.rb
+++ b/lib/web3.rb
@@ -39,7 +39,7 @@ class Web3
     end
 
     if !response.success?
-      raise "JSON-RPC endpoint " + @endpoint + " returned http code " + response.code
+      raise "JSON-RPC endpoint " + @endpoint + " returned http code " + response.code.to_s()
     end
 
     if response["error"]


### PR DESCRIPTION
After Bundling in My Rails Project

```ruby

> @web3 = Web3.new("RPC_HOST")
> @web3. eth_coinbase
TypeError: no implicit conversion of Integer into String
from /PATH/.rvm/gems/ruby-2.4.0/gems/web3-0.2.1/lib/web3.rb:42:in `+'

````

And, I add `to_s()` method :)


```ruby
> @web3 = Web3.new("RPC_HOST")
> @web3. eth_coinbase
RuntimeError: JSON-RPC endpoint https://RPC_HOST returned http code 405
```

Return String Working Good !!